### PR TITLE
Pin GitHub Actions to commit SHA

### DIFF
--- a/.github/workflows/build-everything.yml
+++ b/.github/workflows/build-everything.yml
@@ -35,12 +35,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@12fd324f1d0b43274fdc8130f6980590a667c455 # v1
         with:
           ruby-version: '3.1'
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: '3.10' 
       - name: Install kramdown-rfc
@@ -54,7 +54,7 @@ jobs:
       - name: Render Text
         run: xml2rfc draft-tulshibagwale-saag-pushpull-delivery.xml --text
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: my-artifact
           path: |
@@ -74,13 +74,13 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v4.1.7
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
         with:
           name: my-artifact
       - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: .
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

Pin all third-party GitHub Actions to full-length commit SHAs for supply chain security.

## Changes

Actions are pinned to the exact commit matching the version tag. Version preserved as inline comment for readability.

## Context

- Jira: [PRODSEC-132424](https://jira.cs.sys/browse/PRODSEC-132424)
- Pinning reduces supply chain risk by ensuring exact action versions
- Version preserved as comment: `action@<sha> # <version>`

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Confirm pinned SHAs match expected versions

LLM Agent(s) contributed to this PR.